### PR TITLE
Fixing two typos

### DIFF
--- a/templates/numcomp/Allocation.html
+++ b/templates/numcomp/Allocation.html
@@ -25,7 +25,7 @@
                 <p align="justify">
                     {% blocktrans trimmed %}
                         We now ask you to choose how many of the 100 points you would like to invest in option A
-                        (the <i>Piece- rate payment</i>) and how many in option B (the <i>Tournament payment</i>).
+                        (the <i>Piece-rate payment</i>) and how many in option B (the <i>Tournament payment</i>).
                     {% endblocktrans %}
                 </p>
                 <div class="container">

--- a/templates/numcomp/Num0.html
+++ b/templates/numcomp/Num0.html
@@ -70,8 +70,9 @@
                         </td>
                     </tr>
                     <tr>
-                        <td colspan="12"></td>
-                        <td class="center">
+                        <!-- <td colspan="12"></td> -->
+                        <!-- <td class="center"> -->
+                        <td class="center" colspan="12">
                             <div id="success" style="width: 100px;""></div>
                         </td>
                     </tr>


### PR DESCRIPTION
1. Spelling error, on the Allocation page, and
2. Move the Correct/Wrong box to the front of the row, for less of motion on the page for the stage game.